### PR TITLE
Allow empty query parameters in bison_solr for use with filter queries

### DIFF
--- a/R/bison_solr.r
+++ b/R/bison_solr.r
@@ -148,7 +148,7 @@ bison_solr <- function(decimalLatitude=NULL, decimalLongitude=NULL, year=NULL, p
   for(i in seq_along(qu)){
      stuff[i] <- paste0(names(qu)[[i]],':"', qu[[i]], '"')
   }
-  stuff <- paste0(stuff,collapse="+")
+  stuff <- if (length(stuff) == 0) "*:*" else paste0(stuff,collapse="+")
 
   args <- bs_compact(list(q=stuff, wt="json", ...))
 

--- a/tests/testthat/test-bison_solr.R
+++ b/tests/testthat/test-bison_solr.R
@@ -7,6 +7,7 @@ test_that("bison returns the correct value", {
   out_1 <- bison_solr(scientificName='Ursus americanus', verbose = FALSE)
   out_2 <- bison_solr(scientificName='Ursus americanus', state_code='New Mexico', fl="scientificName", verbose = FALSE)
   out_3 <- bison_solr(scientificName='Ursus americanus', state_code='New Mexico', rows=50, fl="occurrence_date,scientificName", verbose = FALSE)
+  out_4 <- bison_solr()
   out_5 <- bison_solr(scientificName='Helianthus annuus', rows=800, verbose = FALSE)
   out_5_map <- bisonmap(out_5)
 
@@ -14,6 +15,7 @@ test_that("bison returns the correct value", {
   expect_that(out_1$facets$facet_queries, equals(NULL))
   expect_that(out_2$highlight, equals(NULL))
   expect_that(out_2$points[[1]][1], equals("Ursus americanus"))
+  expect_that(nrow(out_4$points), equals(10))
 
   # class
   expect_is(out_1$points, "data.frame")


### PR DESCRIPTION
I often wish to return records from the BISON SOLR interface based only
on filter queries (i.e., I do not specify any normal query parameters).
However, `bison_solr` currently returns nothing unless at least one of
the provided query parameters is specified:

    install.packages("rbison", repos = c(CRAN = "https://cran.rstudio.com/"))

    ## package 'rbison' successfully unpacked and MD5 sums checked
    ## 
    ## The downloaded binary packages are in
    ##  C:\Users\adsmith\AppData\Local\Temp\1\RtmpCUeLY1\downloaded_packages

    library(rbison, quietly = TRUE)
    test <- bison_solr(fq = "decimalLatitude:[33.65 TO 33.75]", 
                       fq = "decimalLongitude:[-85.79 TO -85.72]", 
                       rows = 2000)
    is.null(test$points)

    ## [1] TRUE

I've added the option to not specify any normal query parameters, in
which case a `q=*:*` is passed to the BISON SOLR interface, returning 10
records by default. This then permits queries based only on filter
queries:

    devtools::load_all()
    test <- bison_solr(fq = "decimalLatitude:[33.65 TO 33.75]", 
                       fq = "decimalLongitude:[-85.79 TO -85.72]", 
                       rows = 2000)
    is.null(test$points)

    ## [1] FALSE

    dim(test$points)

    ## [1] 1919   40
