### PR TITLE
Edit description file & add codemeta.json

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,3 +16,4 @@ cran-comments.md
 vignettes/figure
 ^CONDUCT\.md$
 ^cran-comments\.md$
+^codemeta\.json$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,4 +32,5 @@ Suggests:
     taxize
 RoxygenNote: 6.0.1
 X-schema.org-keywords: species, occurrences, biodiversity, maps
-X-schema.org-applicationCategory: "Data Access"
+X-schema.org-applicationCategory: Data Access
+X-schema.org-isPartOf: "https://ropensci.org"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,8 +9,10 @@ Version: 0.5.4.9100
 License: MIT + file LICENSE
 URL: https://github.com/ropensci/rbison
 BugReports: https://github.com/ropensci/rbison/issues
-Authors@R: c(person("Scott", "Chamberlain", role = c("aut", "cre"),
-    email = "myrmecocystus@gmail.com"))
+Authors@R: c(person("Scott", "Chamberlain", 
+    role = c("aut", "cre"),
+    email = "myrmecocystus@gmail.com",
+    comment = "http://orcid.org/0000-0003-1444-9135"))
 LazyData: true
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)
@@ -29,3 +31,5 @@ Suggests:
     testthat,
     taxize
 RoxygenNote: 6.0.1
+X-schema.org-keywords: species, occurrences, biodiversity, maps
+X-schema.org-applicationCategory: "Data Access"

--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,178 @@
+{
+  "@context": ["https://doi.org/doi:10.5063/schema/codemeta-2.0", "http://schema.org"],
+  "@type": "SoftwareSourceCode",
+  "identifier": "rbison",
+  "description": "Interface to the 'USGS' 'BISON' (<https://bison.usgs.gov/>)\n    'API', a 'database' for species occurrence data. Data comes from\n    species in the United States from participating data providers. You can get\n    data via 'taxonomic' and location based queries. A simple function\n    is provided to help visualize data.",
+  "name": "rbison: Interface to the 'USGS' 'BISON' 'API'",
+  "codeRepository": "https://github.com/chrisfan24/rbison.git",
+  "issueTracker": "https://github.com/ropensci/rbison/issues",
+  "license": "https://spdx.org/licenses/MIT",
+  "version": "0.5.4.9100",
+  "programmingLanguage": {
+    "@type": "ComputerLanguage",
+    "name": "R",
+    "version": "3.3.2",
+    "url": "https://r-project.org"
+  },
+  "runtimePlatform": "R version 3.3.2 (2016-10-31)",
+  "provider": {
+    "@id": "https://cran.r-project.org",
+    "@type": "Organization",
+    "name": "Central R Archive Network (CRAN)",
+    "url": "https://cran.r-project.org"
+  },
+  "author": [
+    {
+      "@type": "Person",
+      "givenName": "Scott",
+      "familyName": "Chamberlain",
+      "email": "myrmecocystus@gmail.com",
+      "@id": "http://orcid.org/0000-0003-1444-9135"
+    }
+  ],
+  "maintainer": {
+    "@type": "Person",
+    "givenName": "Scott",
+    "familyName": "Chamberlain",
+    "email": "myrmecocystus@gmail.com",
+    "@id": "http://orcid.org/0000-0003-1444-9135"
+  },
+  "softwareSuggestions": [
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "roxygen2",
+      "name": "roxygen2",
+      "version": "6.0.1",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Central R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      }
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "knitr",
+      "name": "knitr",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Central R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      }
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "testthat",
+      "name": "testthat",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Central R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      }
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "taxize",
+      "name": "taxize",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Central R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      }
+    }
+  ],
+  "softwareRequirements": [
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "plyr",
+      "name": "plyr",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Central R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      }
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "crul",
+      "name": "crul",
+      "version": "0.3.4",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Central R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      }
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "ggplot2",
+      "name": "ggplot2",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Central R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      }
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "mapproj",
+      "name": "mapproj",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Central R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      }
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "grid",
+      "name": "grid"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "sp",
+      "name": "sp",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Central R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      }
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "dplyr",
+      "name": "dplyr",
+      "version": "0.5.0",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Central R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      }
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "jsonlite",
+      "name": "jsonlite",
+      "version": "1.1",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Central R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      }
+    }
+  ],
+  "contIntegration": "https://travis-ci.org/ropensci/rbison",
+  "releaseNotes": "https://github.com/chrisfan24/rbison.git/blob/master/NEWS.md",
+  "readme": "https://github.com/chrisfan24/rbison.git/blob/master/README.md",
+  "fileSize": "687.327KB"
+}

--- a/codemeta.json
+++ b/codemeta.json
@@ -4,7 +4,7 @@
   "identifier": "rbison",
   "description": "Interface to the 'USGS' 'BISON' (<https://bison.usgs.gov/>)\n    'API', a 'database' for species occurrence data. Data comes from\n    species in the United States from participating data providers. You can get\n    data via 'taxonomic' and location based queries. A simple function\n    is provided to help visualize data.",
   "name": "rbison: Interface to the 'USGS' 'BISON' 'API'",
-  "codeRepository": "https://github.com/chrisfan24/rbison.git",
+  "codeRepository": "https://github.com/ropensci/rbison",
   "issueTracker": "https://github.com/ropensci/rbison/issues",
   "license": "https://spdx.org/licenses/MIT",
   "version": "0.5.4.9100",
@@ -171,8 +171,10 @@
       }
     }
   ],
+  "applicationCategory": "DataAccess",
+  "keywords": ["species", "occurrences", "biodiversity", "maps"],
   "contIntegration": "https://travis-ci.org/ropensci/rbison",
-  "releaseNotes": "https://github.com/chrisfan24/rbison.git/blob/master/NEWS.md",
-  "readme": "https://github.com/chrisfan24/rbison.git/blob/master/README.md",
-  "fileSize": "687.327KB"
+  "releaseNotes": "https://github.com/ropensci/rbison/blob/master/NEWS.md",
+  "readme": "https://github.com/ropensci/rbison/blob/master/README.md",
+  "fileSize": "687.334KB"
 }

--- a/codemeta.json
+++ b/codemeta.json
@@ -173,6 +173,7 @@
   ],
   "applicationCategory": "DataAccess",
   "keywords": ["species", "occurrences", "biodiversity", "maps"],
+  "isPartOf": "https://ropensci.org",
   "contIntegration": "https://travis-ci.org/ropensci/rbison",
   "releaseNotes": "https://github.com/ropensci/rbison/blob/master/NEWS.md",
   "readme": "https://github.com/ropensci/rbison/blob/master/README.md",


### PR DESCRIPTION
Edited the description file to add "Data Access" as applicationCategory, keywords as advised by @sckott and @sckott 's ORCID identifier. Then ran write_codemeta to produce a codemeta.json file.

I noticed that in the codemeta.json file, the applicationCategory and keyword aspects didn't show up, but also saw that keywords from DESCRIPTION didn't show up in the codemeta.json file of codemeta/codemetar either. I'd like some clarification on whether I'm looking in the right places / doing this right.

/cc @cboettig 
